### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-js"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cargo-hyperlight",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-js-runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "js-host-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "hyperlight-js",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["src/hyperlight-js", "src/js-host-api", "src/hyperlight-js-runtime"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.89"
 license = "Apache-2.0"
@@ -15,8 +15,8 @@ hyperlight-common = { version = "0.12",  default-features = false }
 hyperlight-guest-bin = { version = "0.12" }
 hyperlight-guest = { version = "0.12" }
 hyperlight-host = { version = "0.12", default-features = false, features = ["executable_heap", "init-paging"] }
-hyperlight-js = { version = "0.1.0", path = "src/hyperlight-js" }
-hyperlight-js-runtime = { version = "0.1.0", path = "src/hyperlight-js-runtime" }
+hyperlight-js = { version = "0.1.1", path = "src/hyperlight-js" }
+hyperlight-js-runtime = { version = "0.1.1", path = "src/hyperlight-js-runtime" }
 
 [profile.dev]
 panic = "abort"


### PR DESCRIPTION
Since the initial 0.1.0 release to crates.io we added some changes to fix the docs.rs build.
This PR bumps the version to 0.1.1 so that we can publish those changes.