### PR TITLE
Add custom labels to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,20 @@ updates:
     schedule:
       interval: "daily"
       time: "03:00"
+    labels:
+      - "kind/dependencies"
   - package-ecosystem: "cargo"
     directories: 
       - "/"
     schedule:
       interval: "daily"
       time: "03:00"
+    labels:
+      - "kind/dependencies"
   - package-ecosystem: "npm"
     directory: "/src/js-host-api"
     schedule:
       interval: "daily"
       time: "03:00"
+    labels:
+      - "kind/dependencies"


### PR DESCRIPTION
This pull request adds the `kind/dependencies` label to dependabot pull requests so that the label checker job passes.