### PR TITLE
Add host function registration for Node.js

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -160,7 +160,7 @@ test-monitors target=default-target:
 test-js-host-api target=default-target features="": (build-js-host-api target features)
     cd src/js-host-api && npm test
 
-# Run js-host-api examples (simple.js, calculator.js, unload.js, interrupt.js, cpu-timeout.js)
+# Run js-host-api examples (simple.js, calculator.js, unload.js, interrupt.js, cpu-timeout.js, host-functions.js)
 run-js-host-api-examples target=default-target features="": (build-js-host-api target features)
     @echo "Running js-host-api examples..."
     @echo ""
@@ -173,6 +173,8 @@ run-js-host-api-examples target=default-target features="": (build-js-host-api t
     cd src/js-host-api && node examples/interrupt.js
     @echo ""
     cd src/js-host-api && node examples/cpu-timeout.js
+    @echo ""
+    cd src/js-host-api && node examples/host-functions.js
     @echo ""
     @echo "✅ All examples completed successfully!"
 

--- a/src/hyperlight-js/src/sandbox/host_fn.rs
+++ b/src/hyperlight-js/src/sandbox/host_fn.rs
@@ -92,6 +92,27 @@ impl HostModule {
         self
     }
 
+    /// Register a raw host function that operates on JSON strings directly.
+    ///
+    /// Unlike [`register`](Self::register), which handles serde serialization /
+    /// deserialization automatically via the [`Function`] trait, this method
+    /// passes the raw JSON string argument from the guest to the closure and
+    /// expects a JSON string result.
+    ///
+    /// This is primarily intended for dynamic / bridge scenarios (e.g. NAPI
+    /// bindings) where argument types are not known at compile time.
+    ///
+    /// Registering a function with the same `name` as an existing function
+    /// overwrites the previous registration.
+    pub fn register_raw(
+        &mut self,
+        name: impl Into<String>,
+        func: impl Fn(String) -> crate::Result<String> + Send + Sync + 'static,
+    ) -> &mut Self {
+        self.functions.insert(name.into(), Box::new(func));
+        self
+    }
+
     pub(crate) fn get(&self, name: &str) -> Option<&BoxFunction> {
         self.functions.get(name)
     }

--- a/src/hyperlight-js/src/sandbox/proto_js_sandbox.rs
+++ b/src/hyperlight-js/src/sandbox/proto_js_sandbox.rs
@@ -212,6 +212,27 @@ impl ProtoJSSandbox {
         self.host_module(module).register(name, func);
         Ok(())
     }
+
+    /// Register a raw host function that operates on JSON strings directly.
+    ///
+    /// This is equivalent to calling `sbox.host_module(module).register_raw(name, func)`.
+    ///
+    /// Unlike [`register`](Self::register), which handles serde serialization /
+    /// deserialization automatically, this method passes the raw JSON string
+    /// from the guest to the callback and expects a JSON string result.
+    ///
+    /// Primarily intended for dynamic / bridge scenarios (e.g. NAPI bindings)
+    /// where argument types are not known at compile time.
+    #[instrument(err(Debug), skip(self, func), level=Level::INFO)]
+    pub fn register_raw(
+        &mut self,
+        module: impl Into<String> + Debug,
+        name: impl Into<String> + Debug,
+        func: impl Fn(String) -> Result<String> + Send + Sync + 'static,
+    ) -> Result<()> {
+        self.host_module(module).register_raw(name, func);
+        Ok(())
+    }
 }
 
 impl std::fmt::Debug for ProtoJSSandbox {

--- a/src/hyperlight-js/tests/host_functions.rs
+++ b/src/hyperlight-js/tests/host_functions.rs
@@ -17,7 +17,7 @@ limitations under the License.
 
 #![allow(clippy::disallowed_macros)]
 
-use hyperlight_js::{SandboxBuilder, Script};
+use hyperlight_js::{new_error, SandboxBuilder, Script};
 
 #[test]
 fn can_call_host_functions() {
@@ -212,4 +212,150 @@ fn host_fn_with_unusual_names() {
         .unwrap();
 
     assert!(res == "42");
+}
+
+#[test]
+fn register_raw_basic() {
+    let handler = Script::from_content(
+        r#"
+        import * as math from "math";
+        function handler(event) {
+            return { result: math.add(10, 32) };
+        }
+        "#,
+    );
+
+    let event = r#"{}"#;
+
+    let mut proto_js_sandbox = SandboxBuilder::new().build().unwrap();
+
+    // register_raw receives the guest args as a JSON string "[10,32]"
+    // and must return a JSON string result.
+    proto_js_sandbox
+        .register_raw("math", "add", |args: String| {
+            let parsed: Vec<i64> = serde_json::from_str(&args)?;
+            let sum: i64 = parsed.iter().sum();
+            Ok(serde_json::to_string(&sum)?)
+        })
+        .unwrap();
+
+    let mut sandbox = proto_js_sandbox.load_runtime().unwrap();
+    sandbox.add_handler("handler", handler).unwrap();
+    let mut loaded_sandbox = sandbox.get_loaded_sandbox().unwrap();
+
+    let res = loaded_sandbox
+        .handle_event("handler", event.to_string(), None)
+        .unwrap();
+
+    assert_eq!(res, r#"{"result":42}"#);
+}
+
+#[test]
+fn register_raw_mixed_with_typed() {
+    let handler = Script::from_content(
+        r#"
+        import * as math from "math";
+        function handler(event) {
+            let sum = math.add(10, 32);
+            let doubled = math.double(sum);
+            return { result: doubled };
+        }
+        "#,
+    );
+
+    let event = r#"{}"#;
+
+    let mut proto_js_sandbox = SandboxBuilder::new().build().unwrap();
+
+    // Typed registration via the Function trait
+    proto_js_sandbox
+        .register("math", "add", |a: i32, b: i32| a + b)
+        .unwrap();
+
+    // Raw registration alongside typed — both in the same module
+    proto_js_sandbox
+        .register_raw("math", "double", |args: String| {
+            let parsed: Vec<i64> = serde_json::from_str(&args)?;
+            let val = parsed.first().copied().unwrap_or(0);
+            Ok(serde_json::to_string(&(val * 2))?)
+        })
+        .unwrap();
+
+    let mut sandbox = proto_js_sandbox.load_runtime().unwrap();
+    sandbox.add_handler("handler", handler).unwrap();
+    let mut loaded_sandbox = sandbox.get_loaded_sandbox().unwrap();
+
+    let res = loaded_sandbox
+        .handle_event("handler", event.to_string(), None)
+        .unwrap();
+
+    assert_eq!(res, r#"{"result":84}"#);
+}
+
+#[test]
+fn register_raw_error_propagation() {
+    let handler = Script::from_content(
+        r#"
+        import * as host from "host";
+        function handler(event) {
+            return host.fail();
+        }
+        "#,
+    );
+
+    let event = r#"{}"#;
+
+    let mut proto_js_sandbox = SandboxBuilder::new().build().unwrap();
+
+    proto_js_sandbox
+        .register_raw("host", "fail", |_args: String| {
+            Err(new_error!("intentional failure from raw host fn"))
+        })
+        .unwrap();
+
+    let mut sandbox = proto_js_sandbox.load_runtime().unwrap();
+    sandbox.add_handler("handler", handler).unwrap();
+    let mut loaded_sandbox = sandbox.get_loaded_sandbox().unwrap();
+
+    let err = loaded_sandbox
+        .handle_event("handler", event.to_string(), None)
+        .unwrap_err();
+
+    assert!(err.to_string().contains("intentional failure"));
+}
+
+#[test]
+fn register_raw_via_host_module() {
+    let handler = Script::from_content(
+        r#"
+        import * as utils from "utils";
+        function handler(event) {
+            let greeting = utils.greet("World");
+            return { greeting };
+        }
+        "#,
+    );
+
+    let event = r#"{}"#;
+
+    let mut proto_js_sandbox = SandboxBuilder::new().build().unwrap();
+
+    // Use host_module() accessor + register_raw() directly on HostModule
+    proto_js_sandbox
+        .host_module("utils")
+        .register_raw("greet", |args: String| {
+            let parsed: Vec<String> = serde_json::from_str(&args)?;
+            let name = parsed.first().cloned().unwrap_or_default();
+            Ok(serde_json::to_string(&format!("Hello, {}!", name))?)
+        });
+
+    let mut sandbox = proto_js_sandbox.load_runtime().unwrap();
+    sandbox.add_handler("handler", handler).unwrap();
+    let mut loaded_sandbox = sandbox.get_loaded_sandbox().unwrap();
+
+    let res = loaded_sandbox
+        .handle_event("handler", event.to_string(), None)
+        .unwrap();
+
+    assert_eq!(res, r#"{"greeting":"Hello, World!"}"#);
 }

--- a/src/js-host-api/Cargo.toml
+++ b/src/js-host-api/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 hyperlight-js = { workspace = true, features = ["monitor-wall-clock", "monitor-cpu-time"] }
-napi = { version = "3.8", features = ["async", "serde-json"] }
+napi = { version = "3.8", features = ["tokio_rt", "serde-json"] }
 napi-derive = "3.5"
 serde_json = "1"
 tokio = { version = "1", features = ["rt"] }

--- a/src/js-host-api/README.md
+++ b/src/js-host-api/README.md
@@ -39,8 +39,10 @@ console.log(result); // { name: 'World', message: 'Hello, World!' }
 
 > **Note:** All sandbox operations that touch the hypervisor (`build`, `loadRuntime`,
 > `getLoadedSandbox`, `callHandler`, `unload`, `snapshot`,
-> `restore`) return Promises. This means the Node.js event loop stays free while
-> the hypervisor does its work — no blocking!
+> `restore`) return Promises and run on background threads (`spawn_blocking`),
+> so they don't block the Node.js event loop. However, if a guest call triggers
+> a host function callback, that callback executes on the main V8 thread
+> (see [Host Functions](#host-functions) for details).
 
 ## API
 
@@ -64,12 +66,20 @@ const protoSandbox = await builder.build();
 
 ### ProtoJSSandbox
 
-A proto sandbox ready to load the JavaScript runtime.
+A proto sandbox ready to load the JavaScript runtime. This is also where
+you register **host functions** — callbacks that guest sandboxed code can
+call. See [Host Functions](#host-functions) below.
 
 **Methods:**
-- `loadRuntime()` → `Promise<JSSandbox>` — Loads the JavaScript runtime into the sandbox
+- `loadRuntime()` → `Promise<JSSandbox>` — Loads the JavaScript runtime into the sandbox. All host functions registered via `hostModule()` / `register()` are applied before the runtime loads.
+- `hostModule(name: string)` → `HostModule` — Create a builder for registering functions in a named module
+- `register(moduleName, functionName, callback)` — Convenience method to register a single host function (args are spread, return value auto-stringified)
 
 ```javascript
+// Register host functions, then load the runtime
+const math = protoSandbox.hostModule('math');
+math.register('add', (a, b) => a + b);
+
 const jsSandbox = await protoSandbox.loadRuntime();
 ```
 
@@ -182,7 +192,7 @@ When both timeouts are set, monitors race with **OR semantics** — whichever fi
 
 ### InterruptHandle ⏱️
 
-Handle for interrupting/killing handler execution. Because all hypervisor calls return Promises, the Node.js event loop stays free during execution — you can call `kill()` from a timer, a signal handler, or any async callback.
+Handle for interrupting/killing handler execution. Because hypervisor calls run on background threads and return Promises, you can call `kill()` from a timer, a signal handler, or any async callback while a handler is running.
 
 **Methods:**
 - `kill()` — Immediately stops the currently executing handler in the sandbox
@@ -259,6 +269,270 @@ try {
 }
 ```
 
+## Host Functions
+
+Host functions let sandboxed guest JavaScript call back into the host
+(Node.js) environment. This is how you extend the sandbox capabilities.
+
+### How It Works
+
+```mermaid
+sequenceDiagram
+    participant Guest as Guest JS (micro-VM)
+    participant HL as Hyperlight Runtime
+    participant Bridge as NAPI Bridge
+    participant Host as Host Callback (Node.js)
+
+    Note over Guest,Host: Registration (before loadRuntime)
+    Host->>Bridge: proto.hostModule('math').register('add', callback)
+    Bridge->>HL: register_raw('math', 'add', closure)
+
+    Note over Guest,Host: Invocation (during callHandler)
+    Guest->>HL: math.add(1, 2)
+    HL->>Bridge: closure("[1,2]")
+    Bridge->>Host: callback("[1,2]")
+    Note right of Host: sync: return immediately<br/>async: await Promise
+    Host-->>Bridge: "3"
+    Bridge-->>HL: Ok("3")
+    HL-->>Guest: 3
+```
+
+1. **Register** host functions on the `ProtoJSSandbox` (before loading the runtime)
+2. **Guest code** imports them as ES modules: `import * as math from "host:math"`
+3. **At call time**, the guest's arguments are JSON-serialised and dispatched to the Node.js main thread via a threadsafe function (V8 is single-threaded, so callbacks *must* execute there). The JSON result is then returned to the guest
+
+### Quick Start
+
+```javascript
+const { SandboxBuilder } = require('@hyperlight/js-host-api');
+
+const proto = await new SandboxBuilder().build();
+
+// Register a sync host function — args are spread, return auto-stringified
+proto.hostModule('math').register('add', (a, b) => a + b);
+
+// Load the runtime (applies all registrations)
+const sandbox = await proto.loadRuntime();
+
+// Guest code can now call math.add()
+sandbox.addHandler('handler', `
+    import * as math from "host:math";
+    function handler(event) {
+        return { result: math.add(event.a, event.b) };
+    }
+`);
+
+const loaded = await sandbox.getLoadedSandbox();
+const result = await loaded.callHandler('handler', { a: 10, b: 32 });
+console.log(result); // { result: 42 }
+```
+
+### The JSON Wire Protocol
+
+All arguments and return values cross the sandbox boundary as **JSON strings**.
+With `register()`, this is handled automatically — your callback receives
+individual arguments (parsed from the JSON array) and the return value is
+automatically `JSON.stringify`'d.
+
+```javascript
+// Guest calls: math.add(1, 2)
+// Your callback receives: (1, 2) — individual args, already parsed
+// Your return value: 3 — automatically stringified to '3'
+math.register('add', (a, b) => a + b);
+
+// Guest calls: db.query("users")
+// Your callback receives: ("users") — the single string arg
+// Your return value is automatically stringified
+db.register('query', (table) => ({
+    rows: [{ id: 1, name: 'Alice' }],
+}));
+```
+
+> **Why JSON strings?** The guest runs in a separate micro-VM with its own
+> JavaScript engine. There's no shared object graph — serialisation is the
+> only way to cross the boundary. JSON is universal, debuggable, and fast
+> enough for the vast majority of use cases.
+
+### API Reference
+
+#### `proto.hostModule(name)` → `HostModule`
+
+Creates a builder for a named module. The module name is what guest code
+uses in its `import` statement.
+
+```javascript
+const math = proto.hostModule('math');
+// Guest: import * as math from "host:math";
+```
+
+Throws `ERR_INVALID_ARG` if name is empty.
+
+#### `builder.register(name, callback)` → `HostModule`
+
+Registers a function within the module. Returns the builder for chaining.
+Arguments are auto-parsed from the guest's JSON array and spread into your
+callback. The return value is automatically `JSON.stringify`'d.
+
+```javascript
+const math = proto.hostModule('math');
+math.register('add', (a, b) => a + b);
+math.register('multiply', (a, b) => a * b);
+```
+
+Throws `ERR_INVALID_ARG` if function name is empty.
+
+#### `proto.register(moduleName, functionName, callback)`
+
+Convenience shorthand — equivalent to `proto.hostModule(moduleName).register(functionName, callback)`.
+
+```javascript
+proto.register('strings', 'upper', (s) => s.toUpperCase());
+```
+
+### Async Callbacks
+
+Host function callbacks can be `async` or return a `Promise`. The bridge
+automatically awaits the result before returning to the guest:
+
+```javascript
+proto.hostModule('api').register('fetchUser', async (userId) => {
+    const response = await fetch(`https://api.example.com/users/${userId}`);
+    return await response.json();
+});
+```
+
+From the guest's perspective, the call is still synchronous — `api.fetchUser(42)`
+blocks until the host's async work completes. The callback runs on the Node.js
+main thread (V8 is single-threaded), so **synchronous callbacks briefly occupy
+the event loop**. For `async` callbacks, the event loop is free during awaited
+I/O (database queries, HTTP requests, etc.) — just like any other async
+Node.js code.
+
+> **Important — why the guest blocks today:**
+>
+> Hyperlight's host function type is synchronous:
+> ```rust
+> type BoxFunction = Box<dyn Fn(String) -> Result<String> + Send + Sync>
+> ```
+> When guest code calls `math.add(1, 2)`, the QuickJS VM inside the micro-VM
+> freezes — it's a blocking `Fn` call, not a `Future`. There's no suspend/resume
+> mechanism in hyperlight-host or hyperlight-common today.
+>
+> The NAPI bridge uses a `ThreadsafeFunction` to dispatch callbacks to the
+> Node.js main thread and waits for the result via a oneshot channel. This
+> allows both sync and async JS callbacks to work transparently.
+
+### Error Handling
+
+If your callback throws (sync) or rejects (async), the error propagates
+to the guest as a `HostFunctionError`:
+
+```javascript
+proto.hostModule('auth').register('validate', (token) => {
+    if (!token) {
+        throw new Error('Token is required');
+    }
+    return { valid: true };
+});
+```
+
+```javascript
+// Guest code
+import * as auth from "host:auth";
+function handler(event) {
+    try {
+        return auth.validate(event.token);
+    } catch (e) {
+        return { error: e.message };
+    }
+}
+```
+
+### Registration Timing
+
+Host functions must be registered **before** calling `loadRuntime()`.
+Registrations are accumulated and applied in bulk when the runtime loads.
+
+```javascript
+const proto = await new SandboxBuilder().build();
+
+// ✅ Register before loadRuntime()
+proto.hostModule('math').register('add', (a, b) => a + b);
+proto.hostModule('strings').register('upper', (s) => s.toUpperCase());
+
+const sandbox = await proto.loadRuntime(); // all registrations applied here
+```
+
+### Snapshot / Restore
+
+Host functions survive snapshot/restore cycles. The snapshot captures the
+guest micro-VM's memory — the host-side JS callbacks live in the Node.js
+process and are unaffected by restore:
+
+```javascript
+// Host-side counter — lives in Node.js, outside the micro-VM
+let callCount = 0;
+
+const proto = await new SandboxBuilder().build();
+proto.register('stats', 'hit', () => {
+    callCount++;
+    return callCount;
+});
+
+const sandbox = await proto.loadRuntime();
+sandbox.addHandler('handler', `
+    import * as stats from "host:stats";
+    function handler() {
+        return { count: stats.hit() };
+    }
+`);
+
+const loaded = await sandbox.getLoadedSandbox();
+const snapshot = await loaded.snapshot();
+
+await loaded.callHandler('handler', {}); // callCount → 1
+await loaded.callHandler('handler', {}); // callCount → 2
+
+await loaded.restore(snapshot); // guest VM memory reset, callCount still 2
+
+await loaded.callHandler('handler', {}); // callCount → 3
+```
+
+### Architecture Notes
+
+How the NAPI bridge works under the hood.
+
+**The problem:** Hyperlight's host function dispatch runs on a `spawn_blocking`
+thread (so it doesn't block the Node.js event loop). But the JS callback must
+run on the main V8 thread. And the callback might be `async`.
+
+**The solution — ThreadsafeFunction with return value:**
+
+```
+spawn_blocking thread          Node.js main thread
+────────────────────           ────────────────────
+1. Parse args from JSON
+2. Create oneshot channel
+3. Fire TSFN with             
+   (args, callback) ──────► 4. TSFN calls JS callback with
+                                  spread args
+                               5. Callback returns (sync or
+                                  Promise)
+                               6. Result sent via callback
+◄──────────────────────────── 
+7. block_on(receiver)
+   gets the Promise
+8. await Promise
+9. JSON stringify result
+10. Return to guest
+```
+
+This design:
+- Works for **both** sync and async JS callbacks
+- For `async` callbacks, the event loop is free during awaited I/O (sync callbacks briefly occupy it — V8 is single-threaded)
+- Uses napi-rs `call_with_return_value` for simple async result handling
+- JSON serialization is handled automatically by the bridge
+
 ## Examples
 
 See the `examples/` directory for complete examples:
@@ -277,6 +551,11 @@ Timeout-based handler termination using wall-clock timeout. Demonstrates killing
 
 ### CPU Timeout (`cpu-timeout.js`) 🚀
 Combined CPU + wall-clock monitoring — the recommended pattern for comprehensive resource protection. Demonstrates OR semantics where the CPU monitor fires first for compute-bound work, with wall-clock as backstop.
+
+### Host Functions (`host-functions.js`)
+Registering sync and async host functions that guest code can call. Demonstrates
+`hostModule().register()` with spread args, `async` callbacks, and the convenience
+`register()` API.
 
 ## Requirements
 

--- a/src/js-host-api/examples/host-functions.js
+++ b/src/js-host-api/examples/host-functions.js
@@ -1,0 +1,89 @@
+// Host Functions example — register host-side callbacks that guest JS can call
+//
+// Demonstrates:
+// - Sync host functions (immediate return)
+// - Async host functions (Promise-returning)
+// - Multiple modules and functions
+// - HostModule API and convenience register() API
+
+const { SandboxBuilder } = require('../lib.js');
+
+async function main() {
+    console.log('=== Hyperlight JS Host Functions ===\n');
+
+    // ── Build the proto sandbox ──────────────────────────────────────
+    console.log('1. Creating sandbox...');
+    const proto = await new SandboxBuilder()
+        .setHeapSize(8 * 1024 * 1024)
+        .setScratchSize(1024 * 1024)
+        .build();
+    console.log('   ✓ Proto sandbox created\n');
+
+    // ── Register host functions (sync, spread args) ──────────────────
+    // Guest JS imports these as: import * as math from "host:math"
+    // Args are auto-parsed from JSON and spread; return value auto-stringified.
+    console.log('2. Registering host functions...');
+
+    const math = proto.hostModule('math');
+
+    math.register('add', (a, b) => a + b);
+    math.register('multiply', (a, b) => a * b);
+
+    // ── Register an async host function ──────────────────────────────
+    // Async callbacks are automatically awaited by the bridge.
+    // The guest call still blocks (Hyperlight is sync), but the host
+    // can do async work (DB queries, HTTP, file I/O, etc.)
+    proto.hostModule('greetings').register('hello', async (name) => {
+        // Simulate async work (e.g. looking up a name in a database)
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return `Hello, ${name}! 👋`;
+    });
+
+    // ── Convenience API: register(module, name, callback) ────────────
+    proto.register('strings', 'upper', (s) => s.toUpperCase());
+
+    console.log('   ✓ Host functions registered\n');
+
+    // ── Load runtime and add a handler ───────────────────────────────
+    console.log('3. Loading runtime...');
+    const sandbox = await proto.loadRuntime();
+    console.log('   ✓ Runtime loaded\n');
+
+    console.log('4. Adding handler...');
+    sandbox.addHandler(
+        'handler',
+        `
+        import * as math from "host:math";
+        import * as greetings from "host:greetings";
+        import * as strings from "host:strings";
+
+        function handler(event) {
+            const sum = math.add(event.a, event.b);
+            const product = math.multiply(event.a, event.b);
+            const greeting = greetings.hello(event.name);
+            const shout = strings.upper(event.message);
+
+            return { sum, product, greeting, shout };
+        }
+        `
+    );
+    const loaded = await sandbox.getLoadedSandbox();
+    console.log('   ✓ Handler ready\n');
+
+    // ── Call the handler ─────────────────────────────────────────────
+    console.log('5. Calling handler...');
+    const result = await loaded.callHandler('handler', {
+        a: 6,
+        b: 7,
+        name: 'World',
+        message: 'hyperlight is rad',
+    });
+
+    console.log('   Result:', JSON.stringify(result, null, 2));
+    console.log('\n✅ Host functions example complete!');
+}
+
+main().catch((err) => {
+    console.error('Error:', err);
+    process.exit(1);
+});

--- a/src/js-host-api/lib.js
+++ b/src/js-host-api/lib.js
@@ -117,7 +117,7 @@ function wrapSync(fn) {
 // cached by require(), so prototypes are patched once per process, after
 // this module has been required at least once.
 
-const { LoadedJSSandbox, JSSandbox, ProtoJSSandbox, SandboxBuilder } = native;
+const { LoadedJSSandbox, JSSandbox, ProtoJSSandbox, SandboxBuilder, HostModule } = native;
 
 /**
  * Wrap a getter so that thrown errors have enriched codes.
@@ -162,8 +162,36 @@ for (const method of ['addHandler', 'removeHandler', 'clearHandlers']) {
 }
 wrapGetter(JSSandbox, 'poisoned');
 
-// ProtoJSSandbox — async
+// ProtoJSSandbox — async + sync methods
 ProtoJSSandbox.prototype.loadRuntime = wrapAsync(ProtoJSSandbox.prototype.loadRuntime);
+
+// hostModule() is sync — just wrap for error enrichment
+ProtoJSSandbox.prototype.hostModule = wrapSync(ProtoJSSandbox.prototype.hostModule);
+
+// ProtoJSSandbox — register() handle errors and wraps callback to return Promise
+{
+    const origRegister = ProtoJSSandbox.prototype.register;
+    ProtoJSSandbox.prototype.register = wrapSync(function (moduleName, functionName, callback) {
+        // the rust code expects the host function to return a Promise, so we wrap the callback result in Promise.resolve().then(..) to allow sync functions as well
+        // note that Promise.resolve(callback(...args)) would not work because if callback throws that would not return a rejected promise, it would just throw before returning the promise.
+        return origRegister.call(this, moduleName, functionName, (...args) =>
+            Promise.resolve().then(() => callback(...args))
+        );
+    });
+}
+
+// HostModule — register()
+{
+    const origRegister = HostModule.prototype.register;
+    if (!origRegister) throw new Error('Cannot wrap missing method: HostModule.register');
+    HostModule.prototype.register = wrapSync(function (name, callback) {
+        // the rust code expects the host function to return a Promise, so we wrap the callback result in Promise.resolve().then(..) to allow sync functions as well
+        // note that Promise.resolve(callback(...args)) would not work because if callback throws that would not return a rejected promise, it would just throw before returning the promise.
+        return origRegister.call(this, name, (...args) =>
+            Promise.resolve().then(() => callback(...args))
+        );
+    });
+}
 
 // SandboxBuilder — async build + sync setters
 SandboxBuilder.prototype.build = wrapAsync(SandboxBuilder.prototype.build);

--- a/src/js-host-api/src/lib.rs
+++ b/src/js-host-api/src/lib.rs
@@ -21,8 +21,13 @@ use hyperlight_js::{
     CpuTimeMonitor, HyperlightError, InterruptHandle, JSSandbox, LoadedJSSandbox, ProtoJSSandbox,
     SandboxBuilder, Script, Snapshot, WallClockMonitor,
 };
+use napi::bindgen_prelude::{JsValuesTupleIntoVec, Promise, ToNapiValue};
+use napi::sys::{napi_env, napi_value};
+use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
+use napi::{tokio, Status};
 use napi_derive::napi;
 use serde_json::Value as JsonValue;
+use tokio::sync::oneshot;
 
 // ── napi-rs wrapper architecture ──────────────────────────────────────
 //
@@ -133,6 +138,17 @@ const MIN_TIMEOUT_MS: u32 = 1;
 /// via ECMAScript's ToUint32 conversion) and other unreasonable durations.
 const MAX_TIMEOUT_MS: u32 = 3_600_000;
 
+/// Prefix automatically prepended to host module names before passing them
+/// to the Rust `ProtoJSSandbox`.
+///
+/// Guest JavaScript imports host modules as `import * as m from "host:m"`.
+/// This makes it structurally impossible for a host module to collide with
+/// a built-in QuickJS native module (`io`, `crypto`, `console`, `require`).
+///
+/// The prefix is applied here in the NAPI layer — the underlying Rust
+/// library stores the exact module name it receives, with no transformation.
+const HOST_MODULE_PREFIX: &str = "host:";
+
 /// Creates a napi error with a `[ERR_CODE]` prefix in the message.
 ///
 /// The JS wrapper (`lib.js`) parses this prefix and promotes it to
@@ -173,6 +189,14 @@ fn consumed_error(type_name: &str) -> napi::Error {
 /// Creates an error for invalid argument conditions.
 fn invalid_arg_error(msg: &str) -> napi::Error {
     hl_error(ErrorCode::InvalidArg, msg)
+}
+
+/// Validates a host module name: must be non-empty.
+fn validate_module_name(name: &str) -> napi::Result<()> {
+    if name.is_empty() {
+        return Err(invalid_arg_error("Module name must not be empty"));
+    }
+    Ok(())
 }
 
 /// Creates an error when a Mutex is poisoned (Rust-level, not sandbox-level).
@@ -368,19 +392,38 @@ impl SandboxBuilderWrapper {
 
 /// A sandbox with VM resources allocated, ready to load the JS runtime.
 ///
-/// This is a transitional state — call `loadRuntime()` to proceed to
-/// `JSSandbox` where you can register handlers.
+/// This is a transitional state — register host functions with
+/// `hostModule()` / `register()`, then call `loadRuntime()` to proceed
+/// to `JSSandbox` where you can register handlers.
 ///
 /// ```js
 /// const proto = await new SandboxBuilder().build();
+///
+/// // Register host functions callable from guest JS
+/// const math = proto.hostModule('math');
+/// math.register('add', (a, b) => a + b);
+///
 /// const sandbox = await proto.loadRuntime();
 /// ```
 #[napi(js_name = "ProtoJSSandbox")]
+#[derive(Clone)]
 pub struct ProtoJSSandboxWrapper {
     inner: Arc<Mutex<Option<ProtoJSSandbox>>>,
 }
 
 impl ProtoJSSandboxWrapper {
+    /// Borrow the inner value mutably via Mutex, or error if consumed.
+    fn with_inner_mut<F, R>(&self, f: F) -> napi::Result<R>
+    where
+        F: FnOnce(&mut ProtoJSSandbox) -> napi::Result<R>,
+    {
+        let mut guard = self.inner.lock().map_err(|_| lock_error())?;
+        let sandbox = guard
+            .as_mut()
+            .ok_or_else(|| consumed_error("ProtoJSSandbox"))?;
+        f(sandbox)
+    }
+
     /// Take ownership of the inner value, returning a consumed-state error if
     /// this instance has already been used.
     fn take_inner(&self) -> napi::Result<ProtoJSSandbox> {
@@ -396,9 +439,9 @@ impl ProtoJSSandboxWrapper {
 impl ProtoJSSandboxWrapper {
     /// Load the JavaScript runtime into the sandbox.
     ///
-    /// This is an expensive operation — the QuickJS engine is initialized
-    /// inside the sandbox. The `ProtoJSSandbox` is consumed and cannot be
-    /// reused.
+    /// All host functions registered via `hostModule()` / `register()`
+    /// are applied before the runtime is loaded. The `ProtoJSSandbox` is
+    /// consumed and cannot be reused.
     ///
     /// Returns a `Promise` — does not block the Node.js event loop.
     ///
@@ -407,6 +450,7 @@ impl ProtoJSSandboxWrapper {
     #[napi]
     pub async fn load_runtime(&self) -> napi::Result<JSSandboxWrapper> {
         let proto_sandbox = self.take_inner()?;
+
         let js_sandbox = tokio::task::spawn_blocking(move || {
             proto_sandbox.load_runtime().map_err(to_napi_error)
         })
@@ -415,6 +459,200 @@ impl ProtoJSSandboxWrapper {
         Ok(JSSandboxWrapper {
             inner: Arc::new(Mutex::new(Some(js_sandbox))),
         })
+    }
+
+    /// Get a builder for registering host functions in a named module.
+    ///
+    /// Host modules are namespaces for host functions that guest JavaScript
+    /// can import:
+    ///
+    /// ```js
+    /// // Host side (Node.js)
+    /// const math = proto.hostModule('math');
+    /// math.register('add', (a, b) => a + b);
+    ///
+    /// // Guest side (sandboxed JS)
+    /// import * as math from "host:math";
+    /// const result = math.add(1, 2); // calls host function
+    /// ```
+    ///
+    /// The returned `HostModule` stores registrations that are
+    /// applied during `loadRuntime()`.
+    ///
+    /// @param name - Module name that guest JS uses in `import * as name from "host:name"`
+    /// @returns A `HostModule` for registering functions
+    /// @throws If the module name is empty
+    #[napi]
+    pub fn host_module(&self, name: String) -> napi::Result<HostModuleWrapper> {
+        validate_module_name(&name)?;
+        Ok(HostModuleWrapper {
+            module_name: format!("{HOST_MODULE_PREFIX}{name}"),
+            sandbox: self.clone(),
+        })
+    }
+
+    /// Register a host function in a named module (convenience method).
+    ///
+    /// Equivalent to `proto.hostModule(module).register(name, callback)`.
+    /// The `host:` prefix is added automatically — guest code imports with
+    /// `from "host:<moduleName>"`.
+    ///
+    /// Arguments are automatically parsed from JSON and spread into your
+    /// callback. The return value is automatically JSON-stringified.
+    ///
+    /// @param moduleName - Bare module name (e.g. `'math'`); guest imports as `"host:math"`
+    /// @param functionName - Function name within the module
+    /// @param callback - `(...args) => any | Promise<any>` — the host function implementation
+    /// @throws If module name or function name is empty
+    #[napi]
+    #[allow(clippy::type_complexity)] // allow the type complexity here so that index.d.ts is cleaner
+    pub fn register(
+        &self,
+        module_name: String,
+        function_name: String,
+        func: ThreadsafeFunction<
+            Rest<Option<serde_json::Value>>,
+            Promise<Option<serde_json::Value>>,
+            Rest<Option<serde_json::Value>>,
+            Status,
+            false,
+            true,
+        >,
+    ) -> napi::Result<()> {
+        self.host_module(module_name)?.register(function_name, func)
+    }
+}
+
+/// Napi takes a tuple of values as the generic for `ThreadsafeFunction`'s input arguments.
+/// This wrapper allows us to take a variable number of arguments in a `Vec` instead of a tuple with a fixed number of elements.
+pub struct Rest<T: ToNapiValue>(pub Vec<T>);
+
+impl<T: ToNapiValue> JsValuesTupleIntoVec for Rest<T> {
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    fn into_vec(self, env: napi_env) -> napi::Result<Vec<napi_value>> {
+        self.0
+            .into_iter()
+            .map(|v| unsafe { T::to_napi_value(env, v) })
+            .collect()
+    }
+}
+
+// ── HostModule ───────────────────────────────────────────────────────
+
+/// A builder for registering host functions in a named module.
+///
+/// Obtained from `ProtoJSSandbox.hostModule(name)`. Host functions
+/// registered here become available to guest JavaScript code via
+/// `import * as <name> from "host:<name>"` after `loadRuntime()` is called.
+///
+/// The `host:` prefix is added automatically by the NAPI layer to prevent
+/// collisions with built-in QuickJS modules (e.g. `io`, `crypto`).
+/// You register with a bare name (`'math'`) and guest code imports with the
+/// prefix (`from "host:math"`).
+///
+/// ```js
+/// // Host side (Node.js)
+/// const math = proto.hostModule('math');
+/// math.register('add', (a, b) => a + b);
+/// math.register('multiply', (a, b) => a * b);
+///
+/// // Guest side (sandboxed JS)
+/// import * as math from "host:math";
+/// math.add(1, 2);       // calls host function
+/// math.multiply(3, 4);  // calls host function
+/// ```
+///
+/// Arguments are automatically parsed from JSON and spread into your
+/// callback. The return value is automatically JSON-stringified.
+#[napi(js_name = "HostModule")]
+pub struct HostModuleWrapper {
+    /// Module name this builder registers functions under.
+    module_name: String,
+
+    /// Reference to the parent `ProtoJSSandboxWrapper`'s inner sandbox, for
+    /// applying registrations.
+    sandbox: ProtoJSSandboxWrapper,
+}
+
+#[napi]
+impl HostModuleWrapper {
+    /// Register a host function in this module.
+    ///
+    /// Arguments are automatically parsed from JSON and spread into your
+    /// callback. The return value is automatically JSON-stringified.
+    /// Both sync and async callbacks are supported — if the callback
+    /// returns a `Promise`, the bridge awaits it automatically.
+    ///
+    /// Registering a function with the same name as an existing one in
+    /// this module overwrites the previous registration.
+    ///
+    /// ```js
+    /// const math = proto.hostModule('math');
+    ///
+    /// // Sync callback — args are spread, return value auto-stringified
+    /// math.register('add', (a, b) => a + b);
+    ///
+    /// // Async callback (automatically awaited)
+    /// math.register('fetchData', async (url) => {
+    ///     const res = await fetch(url);
+    ///     return res.json();
+    /// });
+    /// ```
+    ///
+    /// @param name - Function name within the module (must be non-empty)
+    /// @param callback - `(...args) => any | Promise<any>` — the host function
+    /// @throws If the function name is empty
+    #[napi]
+    #[allow(clippy::type_complexity)] // allow the type complexity here so that index.d.ts is cleaner
+    pub fn register(
+        &self,
+        name: String,
+        func: ThreadsafeFunction<
+            Rest<Option<serde_json::Value>>,
+            Promise<Option<serde_json::Value>>,
+            Rest<Option<serde_json::Value>>,
+            Status,
+            false,
+            true,
+        >,
+    ) -> napi::Result<()> {
+        if name.is_empty() {
+            return Err(invalid_arg_error("Function name must not be empty"));
+        }
+        let wrapper = move |args: String| -> hyperlight_js::Result<String> {
+            use ThreadsafeFunctionCallMode::NonBlocking;
+            let args: Vec<Option<serde_json::Value>> = serde_json::from_str(&args)?;
+            let (tx, rx) = oneshot::channel();
+            let status = func.call_with_return_value(Rest(args), NonBlocking, move |result, _| {
+                let _ = tx.send(result);
+                Ok(())
+            });
+            if status != Status::Ok {
+                return Err(HyperlightError::Error(format!(
+                    "Host function call failed: {status:?}"
+                )));
+            }
+            tokio::runtime::Handle::current().block_on(async move {
+                let promise = rx
+                    .await
+                    .map_err(|_| HyperlightError::Error("Channel closed".into()))?
+                    .map_err(|err| HyperlightError::Error(format!("{err}")))?;
+
+                let value = promise
+                    .await
+                    .map_err(|err| HyperlightError::Error(format!("{err}")))?;
+
+                let value = serde_json::to_string(&value)?;
+                Ok(value)
+            })
+        };
+        self.sandbox.with_inner_mut(|sandbox| {
+            sandbox
+                .host_module(&self.module_name)
+                .register_raw(name, wrapper);
+            Ok(())
+        })?;
+        Ok(())
     }
 }
 

--- a/src/js-host-api/tests/host-functions.test.js
+++ b/src/js-host-api/tests/host-functions.test.js
@@ -1,0 +1,545 @@
+// Host function registration and invocation tests
+//
+// Tests the NAPI bridge for registering host-side JS callbacks that guest
+// sandboxed code can call via `import * as <module> from "host:<module>"`.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SandboxBuilder } from '../lib.js';
+import { expectThrowsWithCode } from './test-helpers.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Build a full pipeline: proto → register host fns → runtime → add handler → loaded.
+ *
+ * @param {(proto: import('../lib.js').ProtoJSSandbox) => void} registerFns
+ *   — callback to register host functions on the proto sandbox
+ * @param {string} handlerScript
+ *   — guest JS source defining a `handler(event)` function
+ * @returns {Promise<import('../lib.js').LoadedJSSandbox>}
+ */
+async function buildLoadedSandbox(registerFns, handlerScript) {
+    const proto = await new SandboxBuilder().build();
+    registerFns(proto);
+    const sandbox = await proto.loadRuntime();
+    sandbox.addHandler('handler', handlerScript);
+    return sandbox.getLoadedSandbox();
+}
+
+// ── HostModule ────────────────────────────────────────────────
+
+describe('HostModule', () => {
+    let proto;
+
+    beforeEach(async () => {
+        proto = await new SandboxBuilder().build();
+    });
+
+    it('should return a HostModule from hostModule()', () => {
+        const builder = proto.hostModule('math');
+        expect(builder).toBeDefined();
+        expect(typeof builder.register).toBe('function');
+    });
+
+    it('should throw on empty module name', () => {
+        expectThrowsWithCode(() => proto.hostModule(''), 'ERR_INVALID_ARG');
+    });
+
+    it('should throw on empty function name in register()', () => {
+        const builder = proto.hostModule('math');
+        expectThrowsWithCode(() => builder.register('', () => 42), 'ERR_INVALID_ARG');
+    });
+});
+
+// ── ProtoJSSandbox.register() convenience method ─────────────────────
+
+describe('ProtoJSSandbox.register()', () => {
+    let proto;
+
+    beforeEach(async () => {
+        proto = await new SandboxBuilder().build();
+    });
+
+    it('should throw on empty module name', () => {
+        expectThrowsWithCode(() => proto.register('', 'add', () => 42), 'ERR_INVALID_ARG');
+    });
+
+    it('should throw on empty function name', () => {
+        expectThrowsWithCode(() => proto.register('math', '', () => 42), 'ERR_INVALID_ARG');
+    });
+});
+
+// ── Host function invocation (end-to-end) ────────────────────────────
+
+describe('Host function invocation', () => {
+    it('should call a sync host function from guest code', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                proto.hostModule('math').register('add', (a, b) => a + b);
+            },
+            `
+            import * as math from "host:math";
+            function handler(event) {
+                return { result: math.add(event.a, event.b) };
+            }
+            `
+        );
+
+        const result = await loaded.callHandler('handler', { a: 10, b: 32 });
+        expect(result).toEqual({ result: 42 });
+    });
+
+    it('should call an async host function from guest code', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                proto.hostModule('utils').register('greet', async (name) => {
+                    // Simulate async work (e.g., a database lookup)
+                    await new Promise((resolve) => setTimeout(resolve, 10));
+                    return `Hello, ${name}!`;
+                });
+            },
+            `
+            import * as utils from "host:utils";
+            function handler(event) {
+                return { greeting: utils.greet(event.name) };
+            }
+            `
+        );
+
+        const result = await loaded.callHandler('handler', { name: 'World' });
+        expect(result).toEqual({ greeting: 'Hello, World!' });
+    });
+
+    it('should support multiple functions in one module', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                const math = proto.hostModule('math');
+                math.register('add', (a, b) => a + b);
+                math.register('multiply', (a, b) => a * b);
+            },
+            `
+            import * as math from "host:math";
+            function handler(event) {
+                let sum = math.add(event.a, event.b);
+                let product = math.multiply(event.a, event.b);
+                return { sum, product };
+            }
+            `
+        );
+
+        const result = await loaded.callHandler('handler', { a: 6, b: 7 });
+        expect(result).toEqual({ sum: 13, product: 42 });
+    });
+
+    it('should support multiple modules', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                proto.hostModule('math').register('add', (a, b) => a + b);
+                proto.hostModule('strings').register('upper', (s) => s.toUpperCase());
+            },
+            `
+            import * as math from "host:math";
+            import * as strings from "host:strings";
+            function handler(event) {
+                let sum = math.add(event.a, event.b);
+                let upper = strings.upper(event.name);
+                return { sum, upper };
+            }
+            `
+        );
+
+        const result = await loaded.callHandler('handler', { a: 1, b: 2, name: 'hello' });
+        expect(result).toEqual({ sum: 3, upper: 'HELLO' });
+    });
+
+    it('should support the convenience register() method', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                proto.register('math', 'add', (a, b) => a + b);
+            },
+            `
+            import * as math from "host:math";
+            function handler(event) {
+                return { result: math.add(3, 4) };
+            }
+            `
+        );
+
+        const result = await loaded.callHandler('handler', {});
+        expect(result).toEqual({ result: 7 });
+    });
+
+    it('should propagate errors from host function callbacks', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                proto.hostModule('host').register('explode', () => {
+                    throw new Error('💥 kaboom from host');
+                });
+            },
+            `
+            import * as host from "host:host";
+            function handler(event) {
+                return host.explode();
+            }
+            `
+        );
+
+        // The guest catches host errors as HostFunctionError
+        await expect(loaded.callHandler('handler', {})).rejects.toThrow();
+    });
+
+    it('should handle host function returning complex objects', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                proto.hostModule('db').register('query', (table) => ({
+                    rows: [
+                        { id: 1, name: 'Alice' },
+                        { id: 2, name: 'Bob' },
+                    ],
+                    table,
+                }));
+            },
+            `
+            import * as db from "host:db";
+            function handler(event) {
+                let result = db.query(event.table);
+                return { count: result.rows.length, first: result.rows[0].name };
+            }
+            `
+        );
+
+        const result = await loaded.callHandler('handler', { table: 'users' });
+        expect(result).toEqual({ count: 2, first: 'Alice' });
+    });
+
+    it('should work with snapshot/restore cycle', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                let counter = 0;
+                proto.hostModule('state').register('increment', () => {
+                    counter++;
+                    return counter;
+                });
+            },
+            `
+            import * as state from "host:state";
+            function handler(event) {
+                return { count: state.increment() };
+            }
+            `
+        );
+
+        // Take snapshot, call handler, restore, call again
+        const snapshot = await loaded.snapshot();
+        const r1 = await loaded.callHandler('handler', {});
+        expect(r1.count).toBe(1);
+
+        await loaded.restore(snapshot);
+        const r2 = await loaded.callHandler('handler', {});
+        // Host-side counter keeps incrementing (it's outside the sandbox)
+        // but guest state was restored
+        expect(r2.count).toBe(2);
+    });
+
+    // ── register() — host function registration ─────────────────
+
+    it('should support register() on HostModule', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                proto.hostModule('math').register('add', (a, b) => {
+                    return a + b;
+                });
+            },
+            `
+            import * as math from "host:math";
+            function handler(event) {
+                return { result: math.add(event.a, event.b) };
+            }
+            `
+        );
+
+        const result = await loaded.callHandler('handler', { a: 10, b: 32 });
+        expect(result).toEqual({ result: 42 });
+    });
+
+    it('should support register() convenience method', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                proto.register('math', 'add', (a, b) => {
+                    return a + b;
+                });
+            },
+            `
+            import * as math from "host:math";
+            function handler(event) {
+                return { result: math.add(3, 4) };
+            }
+            `
+        );
+
+        const result = await loaded.callHandler('handler', {});
+        expect(result).toEqual({ result: 7 });
+    });
+
+    it('should support async register() callbacks', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                proto.hostModule('utils').register('greet', async (name) => {
+                    await new Promise((resolve) => setTimeout(resolve, 10));
+                    return `Hello, ${name}!`;
+                });
+            },
+            `
+            import * as utils from "host:utils";
+            function handler(event) {
+                return { greeting: utils.greet(event.name) };
+            }
+            `
+        );
+
+        const result = await loaded.callHandler('handler', { name: 'World' });
+        expect(result).toEqual({ greeting: 'Hello, World!' });
+    });
+
+    it('should propagate errors from register() callbacks', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                proto.hostModule('host').register('explode', () => {
+                    throw new Error('💥 async kaboom from host');
+                });
+            },
+            `
+            import * as host from "host:host";
+            function handler(event) {
+                try {
+                    host.explode();
+                    return { success: true };
+                } catch (err) {
+                    return { success: false, error: err.message };
+                }
+            }
+            `
+        );
+
+        // The guest catches host errors as HostFunctionError
+        let result = await loaded.callHandler('handler', {});
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('💥 async kaboom from host');
+    });
+
+    it('should propagate errors from register() async callbacks', async () => {
+        const loaded = await buildLoadedSandbox(
+            (proto) => {
+                proto.hostModule('host').register('explode', async () => {
+                    await new Promise((resolve) => setTimeout(resolve, 10));
+                    throw new Error('💥 async kaboom from host');
+                });
+            },
+            `
+            import * as host from "host:host";
+            function handler(event) {
+                try {
+                    host.explode();
+                    return { success: true };
+                } catch (err) {
+                    return { success: false, error: err.message };
+                }
+            }
+            `
+        );
+
+        // The guest catches host errors as HostFunctionError
+        let result = await loaded.callHandler('handler', {});
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('💥 async kaboom from host');
+    });
+});
+
+// ── Multi-sandbox isolation ──────────────────────────────────────────
+//
+// These tests verify that two sandboxes with the same host function names
+// use independent resolver maps and don't cross-contaminate. This is the
+// "Two sandboxes enter, no data leaves" guarantee.
+
+describe('Multi-sandbox isolation', () => {
+    /**
+     * Build a loaded sandbox with a single host function and handler.
+     * Returns { loaded, tag } so callers can identify which sandbox responded.
+     */
+    async function buildTaggedSandbox(tag, hostFnImpl, handlerScript) {
+        const proto = await new SandboxBuilder().build();
+        hostFnImpl(proto);
+        const sandbox = await proto.loadRuntime();
+        sandbox.addHandler('handler', handlerScript);
+        const loaded = await sandbox.getLoadedSandbox();
+        return { loaded, tag };
+    }
+
+    it('should isolate two sandboxes with same-named host functions (different impls)', async () => {
+        // Sandbox A: math.compute returns a + b
+        const { loaded: loadedA } = await buildTaggedSandbox(
+            'A',
+            (proto) => proto.hostModule('math').register('compute', (a, b) => a + b),
+            `
+            import * as math from "host:math";
+            function handler(event) {
+                return { result: math.compute(event.a, event.b), source: "A" };
+            }
+            `
+        );
+
+        // Sandbox B: math.compute returns a * b (same module, same fn name!)
+        const { loaded: loadedB } = await buildTaggedSandbox(
+            'B',
+            (proto) => proto.hostModule('math').register('compute', (a, b) => a * b),
+            `
+            import * as math from "host:math";
+            function handler(event) {
+                return { result: math.compute(event.a, event.b), source: "B" };
+            }
+            `
+        );
+
+        // Call both — each should hit its own host function
+        const resultA = await loadedA.callHandler('handler', { a: 3, b: 7 });
+        const resultB = await loadedB.callHandler('handler', { a: 3, b: 7 });
+
+        expect(resultA).toEqual({ result: 10, source: 'A' }); // 3 + 7
+        expect(resultB).toEqual({ result: 21, source: 'B' }); // 3 * 7
+    });
+
+    it('should isolate per-sandbox state in host function closures', async () => {
+        // Each sandbox gets its own counter — closures capture different state
+        let counterA = 0;
+        let counterB = 0;
+
+        const { loaded: loadedA } = await buildTaggedSandbox(
+            'A',
+            (proto) =>
+                proto.hostModule('stats').register('hit', () => {
+                    counterA++;
+                    return counterA;
+                }),
+            `
+            import * as stats from "host:stats";
+            function handler() { return { count: stats.hit() }; }
+            `
+        );
+
+        const { loaded: loadedB } = await buildTaggedSandbox(
+            'B',
+            (proto) =>
+                proto.hostModule('stats').register('hit', () => {
+                    counterB++;
+                    return counterB;
+                }),
+            `
+            import * as stats from "host:stats";
+            function handler() { return { count: stats.hit() }; }
+            `
+        );
+
+        // Interleave calls: A, B, A, B, A
+        const a1 = await loadedA.callHandler('handler', {});
+        const b1 = await loadedB.callHandler('handler', {});
+        const a2 = await loadedA.callHandler('handler', {});
+        const b2 = await loadedB.callHandler('handler', {});
+        const a3 = await loadedA.callHandler('handler', {});
+
+        // Each counter should be independent
+        expect(a1).toEqual({ count: 1 });
+        expect(a2).toEqual({ count: 2 });
+        expect(a3).toEqual({ count: 3 });
+        expect(b1).toEqual({ count: 1 });
+        expect(b2).toEqual({ count: 2 });
+
+        // Final state: counterA=3, counterB=2
+        expect(counterA).toBe(3);
+        expect(counterB).toBe(2);
+    });
+
+    it('should isolate async host functions across sandboxes with interleaved calls', async () => {
+        const { loaded: loadedA } = await buildTaggedSandbox(
+            'A',
+            (proto) =>
+                proto.hostModule('net').register('fetch', async (url) => {
+                    await new Promise((resolve) => setTimeout(resolve, 20));
+                    return `A:${url}`;
+                }),
+            `
+            import * as net from "host:net";
+            function handler(event) { return { data: net.fetch(event.url) }; }
+            `
+        );
+
+        const { loaded: loadedB } = await buildTaggedSandbox(
+            'B',
+            (proto) =>
+                proto.hostModule('net').register('fetch', async (url) => {
+                    await new Promise((resolve) => setTimeout(resolve, 20));
+                    return `B:${url}`;
+                }),
+            `
+            import * as net from "host:net";
+            function handler(event) { return { data: net.fetch(event.url) }; }
+            `
+        );
+
+        // Interleave calls — each sandbox's async host fn must resolve
+        // through its own per-sandbox resolver map, not the other's
+        const resultA1 = await loadedA.callHandler('handler', { url: '/api' });
+        const resultB1 = await loadedB.callHandler('handler', { url: '/api' });
+        const resultA2 = await loadedA.callHandler('handler', { url: '/data' });
+        const resultB2 = await loadedB.callHandler('handler', { url: '/data' });
+
+        expect(resultA1).toEqual({ data: 'A:/api' });
+        expect(resultB1).toEqual({ data: 'B:/api' });
+        expect(resultA2).toEqual({ data: 'A:/data' });
+        expect(resultB2).toEqual({ data: 'B:/data' });
+    });
+
+    it('should isolate multiple host functions per sandbox across two sandboxes', async () => {
+        // Both sandboxes register math.add AND math.multiply — but with
+        // different implementations. Exercises multiple TSFNs per sandbox
+        // sharing the same resolver map, across two independent maps.
+        const { loaded: loadedA } = await buildTaggedSandbox(
+            'A',
+            (proto) => {
+                const math = proto.hostModule('math');
+                math.register('add', (a, b) => a + b);
+                math.register('multiply', (a, b) => a * b);
+            },
+            `
+            import * as math from "host:math";
+            function handler(event) {
+                return { sum: math.add(event.a, event.b), product: math.multiply(event.a, event.b) };
+            }
+            `
+        );
+
+        const { loaded: loadedB } = await buildTaggedSandbox(
+            'B',
+            (proto) => {
+                const math = proto.hostModule('math');
+                // Reversed! add does multiply, multiply does add
+                math.register('add', (a, b) => a * b);
+                math.register('multiply', (a, b) => a + b);
+            },
+            `
+            import * as math from "host:math";
+            function handler(event) {
+                return { sum: math.add(event.a, event.b), product: math.multiply(event.a, event.b) };
+            }
+            `
+        );
+
+        const resultA = await loadedA.callHandler('handler', { a: 3, b: 7 });
+        const resultB = await loadedB.callHandler('handler', { a: 3, b: 7 });
+
+        // A: normal — add=10, multiply=21
+        expect(resultA).toEqual({ sum: 10, product: 21 });
+        // B: reversed — add=21, multiply=10
+        expect(resultB).toEqual({ sum: 21, product: 10 });
+    });
+});


### PR DESCRIPTION
Add support for registering host-side JavaScript callbacks that guest sandboxed code can call via ES module imports.

New APIs:
- proto.hostModule(name) - Create a builder for registering functions
- builder.register(name, callback) - Register a host function
- proto.register(module, fn, callback) - Convenience method

Guest code imports host modules as 'import * as math from "host:math"' and calls functions like math.add(1, 2). Arguments are JSON-serialized across the sandbox boundary. Both sync and async callbacks are supported.

Changes:
- hyperlight-js: Add register_raw() for dynamic NAPI scenarios
- js-host-api: Add HostModule wrapper, ThreadsafeFunction bridge
- js-host-api: Update Cargo.toml to use tokio_rt feature
- Add comprehensive tests (22 new JS tests, 4 new Rust tests)
- Add host-functions.js example
- Update README with Host Functions documentation