### PR TITLE
Use the needs_publish (from hyperlight) in CrateRelease workflow

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -17,6 +17,7 @@ jobs:
     secrets: inherit
     with:
         environment: release
+
   benchmarks:
     uses: ./.github/workflows/dep_benchmarks.yml
     secrets: inherit
@@ -51,36 +52,13 @@ jobs:
           echo "Setting version to 'v$version'"
           echo "version=$version" >> $GITHUB_OUTPUT
 
-  publish-hyperlight-js-packages-and-create-release:
+  create-gh-release:
     needs: [build, benchmarks, set-version]
     environment: release
-    runs-on: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd", "JobId=publish-hyperlight-js-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
+    runs-on: ubuntu-latest
     if: ${{ contains(github.ref, 'refs/heads/release/') }}
 
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      # Ensures just is installed using setup wokflow to ensure just version consistency
-      - name: Hyperlight setup
-        uses: hyperlight-dev/ci-setup-workflow@v1.9.0
-        with:
-          rust-toolchain: "1.89"
-          just-version: "1.51"
-
-      - name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@v1
-        id: crates-io-auth
-
-      - name: Publish hyperlight-js
-        run: |
-          cargo publish -p hyperlight-js-runtime
-          cargo publish -p hyperlight-js
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-
       - name: Download benchmarks (Windows)
         uses: actions/download-artifact@v8
         with:
@@ -116,8 +94,15 @@ jobs:
             GH_TOKEN: ${{ github.token }}
 
   publish-npm-packages:
-    needs: [set-version]
+    needs: [build, benchmarks, set-version]
     uses: ./.github/workflows/npm-publish.yml
+    with:
+      version: ${{ needs.set-version.outputs.version }}
+      dry-run: ${{ !contains(github.ref, 'refs/heads/release/') }}
+
+  publish-cargo-crates:
+    needs: [build, benchmarks, set-version]
+    uses: ./.github/workflows/cargo-publish.yml
     with:
       version: ${{ needs.set-version.outputs.version }}
       dry-run: ${{ !contains(github.ref, 'refs/heads/release/') }}

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -1,0 +1,100 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Publish npm packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.2.0)'
+        required: true
+        type: string
+      dry-run:
+        description: 'Dry run (skip actual publish)'
+        required: false
+        type: boolean
+        default: false
+  # IMPORTANT: Trusted publishing (OIDC) is configured on npmjs.com with
+  # workflow filename 'CreateRelease.yml'. npm checks the *calling* workflow
+  # for workflow_call, not the reusable workflow that runs npm publish.
+  # Calling this workflow from a different parent workflow will fail OIDC auth.
+  # See: https://docs.npmjs.com/trusted-publishers#troubleshooting
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to publish'
+        required: true
+        type: string
+      dry-run:
+        description: 'Dry run (skip actual publish)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-hyperlight-packages:
+    runs-on: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd", "JobId=publish-hyperlight-js-packages-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Ensures just is installed using setup wokflow to ensure just version consistency
+      - name: Hyperlight setup
+        uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+        with:
+          rust-toolchain: "1.89"
+          just-version: "1.51"
+
+      - name: Determine which crates need publishing
+        env:
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          needs_publish() {
+            local crate=$1
+            local crate_env_var=$(echo "$crate" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+
+            if [ -z "$VERSION" ] || [ "$VERSION" == "v0.0.0" ] || [ "$VERSION" == "0.0.0" ]; then
+              echo "No version set (dry run?), skipping crates.io existence checks."
+              echo "PUBLISH_${crate_env_var}=true" >> "$GITHUB_ENV"
+              return
+            fi
+
+            if curl -s "https://crates.io/api/v1/crates/$crate/$VERSION" | jq -e .version > /dev/null; then
+              echo "PUBLISH_${crate_env_var}=false" >> "$GITHUB_ENV"
+              echo "✅ $crate@$VERSION already exists."
+            else
+              echo "PUBLISH_${crate_env_var}=true" >> "$GITHUB_ENV"
+              echo "🚀 $crate@$VERSION will be published."
+            fi
+          }
+          
+          needs_publish hyperlight-js-runtime
+          needs_publish hyperlight-js
+
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: crates-io-auth
+
+      - name: Publish hyperlight-js-runtime
+        continue-on-error: ${{ inputs.dry_run }}
+        run: cargo publish --manifest-path ./src/hyperlight-js-runtime/Cargo.toml ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+        if: env.PUBLISH_HYPERLIGHT_JS_RUNTIME != 'false'
+
+      - name: Publish hyperlight-js
+        continue-on-error: ${{ inputs.dry_run }}
+        # this step would normally fail in a dry run as the hyperlight-js-runtime dependency has not actually been published
+        # TODO: fix(jprendes): find a way to actually dry run the publish of hyperlight-js
+        run: cargo publish --manifest-path ./src/hyperlight-js/Cargo.toml ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+        if: env.PUBLISH_HYPERLIGHT_JS != 'false'

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   publish-hyperlight-packages:
-    runs-on: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd", "JobId=publish-hyperlight-js-packages-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
@@ -49,8 +49,11 @@ jobs:
       - name: Hyperlight setup
         uses: hyperlight-dev/ci-setup-workflow@v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.90"
           just-version: "1.51"
+    
+      - name: Install cargo-overlay-registry
+        run: cargo install cargo-overlay-registry
 
       - name: Determine which crates need publishing
         env:
@@ -78,23 +81,31 @@ jobs:
           
           needs_publish hyperlight-js-runtime
           needs_publish hyperlight-js
+    
+      - name: Dry run publishing
+        shell: bash
+        run: |
+            cargo-overlay-registry \
+                -r local \
+                -r local=./target/package/tmp-registry/ \
+                -r crates.io \
+                -- \
+                cargo publish --workspace --dry-run \
+                    -p hyperlight-js \
+                    -p hyperlight-js-runtime
 
       - name: Authenticate with crates.io
         uses: rust-lang/crates-io-auth-action@v1
         id: crates-io-auth
 
       - name: Publish hyperlight-js-runtime
-        continue-on-error: ${{ inputs.dry_run }}
-        run: cargo publish --manifest-path ./src/hyperlight-js-runtime/Cargo.toml ${{ inputs.dry_run && '--dry-run' || '' }}
+        run: cargo publish -p hyperlight-js-runtime
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-        if: env.PUBLISH_HYPERLIGHT_JS_RUNTIME != 'false'
+        if: ${{ env.PUBLISH_HYPERLIGHT_JS_RUNTIME != 'false' && !inputs['dry-run'] }}
 
       - name: Publish hyperlight-js
-        continue-on-error: ${{ inputs.dry_run }}
-        # this step would normally fail in a dry run as the hyperlight-js-runtime dependency has not actually been published
-        # TODO: fix(jprendes): find a way to actually dry run the publish of hyperlight-js
-        run: cargo publish --manifest-path ./src/hyperlight-js/Cargo.toml ${{ inputs.dry_run && '--dry-run' || '' }}
+        run: cargo publish -p hyperlight-js
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-        if: env.PUBLISH_HYPERLIGHT_JS != 'false'
+        if: ${{ env.PUBLISH_HYPERLIGHT_JS != 'false' && !inputs['dry-run'] }}

--- a/.github/workflows/dep_benchmarks.yml
+++ b/.github/workflows/dep_benchmarks.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.90"
           just-version: "1.51"
 
       - name: Install github-cli (Azure Linux)

--- a/.github/workflows/dep_build.yml
+++ b/.github/workflows/dep_build.yml
@@ -61,7 +61,7 @@ jobs:
 
     - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
       with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.90"
           just-version: "1.51"
 
     - name: install nodejs

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Hyperlight setup
         uses: hyperlight-dev/ci-setup-workflow@v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.90"
           just-version: "1.51"
 
       - name: Setup Node.js

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89"
+channel = "1.90"


### PR DESCRIPTION
This PR lets us re-run the CreateRelease workflow and skip already published crates.io packages.
This follows the same pattern as hyperlight core, and would help us in case parts of a release succeed and other parts fail.
It also moves cargo publishing to its own reusable workflow matching the npm publishing workflow.
It also improves dry-run support for crates.io using `cargo-overlay-registry`