### PR TITLE
docs: update clang/LLVM install instructions to v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ For Ubuntu:
 ```bash
     wget https://apt.llvm.org/llvm.sh 
     chmod +x ./llvm.sh
-    sudo ./llvm.sh 16 all
-    sudo ln -s /usr/lib/llvm-16/bin/clang-cl /usr/bin/clang-cl
-    sudo ln -s /usr/lib/llvm-16/bin/llvm-lib /usr/bin/llvm-lib
+    sudo ./llvm.sh 18 all
+    sudo ln -s /usr/lib/llvm-18/bin/clang-cl /usr/bin/clang-cl
+    sudo ln -s /usr/lib/llvm-18/bin/llvm-lib /usr/bin/llvm-lib
 ```
 
 For Azure Linux:
 
 ```bash
     sudo dnf remove clang -y|| true
-    sudo dnf install clang16 -y
-    sudo dnf install clang16-tools-extra -y
+    sudo dnf install clang18 -y
+    sudo dnf install clang18-tools-extra -y
 ```
 
 In addition on Linux you will need to install the `x86_64-unknown-none` target:


### PR DESCRIPTION
## What

Bump the clang/LLVM version in the README setup instructions from **16 → 18** (Ubuntu and Azure Linux sections).

## Why

The README's install steps pinned clang/LLVM 16, but that's stale. The authoritative sources both require/install **18**:

- The parent project's [`getting-started.md`](https://github.com/hyperlight-dev/hyperlight/blob/main/docs/getting-started.md) uses `sudo ./llvm.sh 18`.
- CI (`hyperlight-dev/ci-setup-workflow@v1.9.0`) installs clang 18 (`sudo ./llvm.sh 18 clang clang-tools-extra`) and symlinks `/usr/lib/llvm-18/bin/clang` → `/usr/bin/clang`.

Verified locally: pointing `/usr/bin/clang` at llvm-18 resolves the `rquickjs-sys` bindgen `wint_t`/`__gnuc_va_list` failures that occur under clang 16/older, and the guest cross-compile to `x86_64-hyperlight-none` then succeeds.

## Scope

Pure version bump to keep the diff minimal and reviewable — no structural changes to the install steps.

> Note: this only touches docs; no code changes.