### PR TITLE
Fix npm release lockfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -208,13 +208,8 @@ _test-native-modules-restore target=default-target:
 # old version — which then fails the native_modules `--locked` build. These two
 # recipes keep them in lockstep.
 
-# Bump the version of EVERYTHING in lockstep so a release PR can't end up in a
-# half-bumped, CI-breaking state. In one step this updates:
-#   * all workspace crates + the root Cargo.lock (via cargo-edit)
-#   * the excluded extended_runtime fixture's own Cargo.lock (cargo can't reach it)
-#   * the npm main package, the 3 platform packages, and their optionalDependencies
-#   * the npm package-lock.json (regenerated; the not-yet-published platform
-#     optionals are omitted, matching CI's `npm ci --omit=optional`)
+# Bump all crate and npm package versions together.
+# The publish workflow updates optionalDependencies to the release version.
 # Requires cargo-edit (`cargo install cargo-edit`). ALWAYS use this instead of a
 # bare `cargo set-version` / `npm version` when preparing a release.
 set-version version:
@@ -228,13 +223,8 @@ set-version version:
     cd src/js-host-api/npm/linux-x64-gnu && npm version {{ version }} --no-git-tag-version --allow-same-version --ignore-scripts
     cd src/js-host-api/npm/linux-x64-musl && npm version {{ version }} --no-git-tag-version --allow-same-version --ignore-scripts
     cd src/js-host-api/npm/win32-x64-msvc && npm version {{ version }} --no-git-tag-version --allow-same-version --ignore-scripts
-    # npm: point the main package's optionalDependencies at the new version
-    cd src/js-host-api && npm pkg set \
-        "optionalDependencies.@hyperlight-dev/js-host-api-linux-x64-gnu={{ version }}" \
-        "optionalDependencies.@hyperlight-dev/js-host-api-linux-x64-musl={{ version }}" \
-        "optionalDependencies.@hyperlight-dev/js-host-api-win32-x64-msvc={{ version }}"
-    # npm: regenerate package-lock.json so `npm ci --omit=optional` stays in sync
-    cd src/js-host-api && npm install --package-lock-only --omit=optional --ignore-scripts
+    # Verify the npm lockfile
+    cd src/js-host-api && npm ci --dry-run --omit=optional --ignore-scripts
 
 # Fail fast if the excluded fixture lock has drifted from the workspace version.
 # Without this, drift only surfaces as a cryptic poisoned-LazyLock panic inside

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,8 +10,11 @@ Do this with the `just set-version` recipe. **Always use this instead of bumping
 
 - every workspace crate's `version` and the root `Cargo.lock`,
 - the excluded `extended_runtime` fixture's own `Cargo.lock` (a bare `cargo set-version` can't reach it, and a stale one fails the `native_modules --locked` build),
-- the npm main package, the three platform packages, and their `optionalDependencies`,
-- `src/js-host-api/package-lock.json` (a stale one fails `npm ci` in the publish job).
+- the npm main package and the three platform packages,
+- the root package version in `src/js-host-api/package-lock.json`.
+
+Keep `optionalDependencies` on the latest published version so `npm ci` can use
+the lockfile. The release workflow updates them before publishing.
 
 It uses `cargo set-version` from the `cargo-edit` crate under the hood, so install that first:
 
@@ -29,7 +32,7 @@ We keep the version number consistent across all crates and npm packages in the 
 
 Create a PR with these changes and merge it into the `main` branch.
 
-> **Note:** The `CreateRelease` workflow *also* sets the npm packages to the tag's version at publish time (via `npm version`), so the published artifacts always match the tag regardless. Bumping them in the repo with `just set-version` is what keeps `npm ci` from failing *during* the release — don't skip it.
+> **Note:** The release workflow sets all npm versions from the tag before publishing.
 
 ## Create a tag
 

--- a/src/js-host-api/package-lock.json
+++ b/src/js-host-api/package-lock.json
@@ -19,9 +19,9 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@hyperlight-dev/js-host-api-linux-x64-gnu": "0.4.0",
-        "@hyperlight-dev/js-host-api-linux-x64-musl": "0.4.0",
-        "@hyperlight-dev/js-host-api-win32-x64-msvc": "0.4.0"
+        "@hyperlight-dev/js-host-api-linux-x64-gnu": "0.3.3",
+        "@hyperlight-dev/js-host-api-linux-x64-musl": "0.3.3",
+        "@hyperlight-dev/js-host-api-win32-x64-msvc": "0.3.3"
       }
     },
     "node_modules/@emnapi/core": {
@@ -251,6 +251,60 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@hyperlight-dev/js-host-api-linux-x64-gnu": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@hyperlight-dev/js-host-api-linux-x64-gnu/-/js-host-api-linux-x64-gnu-0.3.3.tgz",
+      "integrity": "sha512-DO26tGQoaiwM1iWikPdjMVPxm4Ge6IWtdfCoZLGnntEnlRSCoa6DB3/fwW8ihZM++vaoWm1WzW8TBoOe8qxHuA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@hyperlight-dev/js-host-api-linux-x64-musl": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@hyperlight-dev/js-host-api-linux-x64-musl/-/js-host-api-linux-x64-musl-0.3.3.tgz",
+      "integrity": "sha512-8PnXByjWmxmTFGDT8cwaQD8oaz3JBeD6WF5F2p/ncO32eakl7Ll490J9McR9Mcp6rX1RmgrIRuiT9b9U+VDgKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@hyperlight-dev/js-host-api-win32-x64-msvc": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@hyperlight-dev/js-host-api-win32-x64-msvc/-/js-host-api-win32-x64-msvc-0.3.3.tgz",
+      "integrity": "sha512-5TQ5g9/qLBPIYtq8lY2xPsevBiWJ1k8CFykDU2kc2u4dRRRF/XYs/TH7BWjQnE9+rSJrwg4YxDRzt6CoMAp19g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@inquirer/ansi": {

--- a/src/js-host-api/package.json
+++ b/src/js-host-api/package.json
@@ -35,9 +35,9 @@
   },
   "license": "Apache-2.0",
   "optionalDependencies": {
-    "@hyperlight-dev/js-host-api-linux-x64-gnu": "0.4.0",
-    "@hyperlight-dev/js-host-api-linux-x64-musl": "0.4.0",
-    "@hyperlight-dev/js-host-api-win32-x64-msvc": "0.4.0"
+    "@hyperlight-dev/js-host-api-linux-x64-gnu": "0.3.3",
+    "@hyperlight-dev/js-host-api-linux-x64-musl": "0.3.3",
+    "@hyperlight-dev/js-host-api-win32-x64-msvc": "0.3.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Fix the npm release dry run by keeping optional platform dependencies on the latest published version until the release workflow updates them.

https://github.com/hyperlight-dev/hyperlight-js/pull/238 introduced `just set-version` but it was never tested and didn't work (as can be seen when my [pr](https://github.com/hyperlight-dev/hyperlight-js/pull/290) was merged and prerelease job [failed](https://github.com/hyperlight-dev/hyperlight-js/actions/runs/33669351728/job/100388715167)) 